### PR TITLE
Travis build is failing for to deploy documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ addons:
   ssh_known_hosts: 13.229.163.131
 
 before_install:
-  - sudo pip install -U virtualenv pre-commit pip
+  - sudo pip install -U virtualenv pre-commit
 
 script:
   - if [[ "$JOB" == "pre_commit" ]]; then sudo ln -s /usr/bin/clang-format-3.8 /usr/bin/clang-format; fi


### PR DESCRIPTION
I suspect it's because of upgraded pip.  This line removes the upgrade